### PR TITLE
add github pages link for users using browser IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ By the end of this lesson, you'll be able to
 
 Creating an element in JavaScript couldn't be easier. Simply call `document.createElement(tagName)`, where `tagName` is the string representation of any valid HTML tag (e.g., `'p'`, `'div'`, `'span'`, etc.).
 
-Open this lesson's `index.html` file in your browser and open up the browser's console. In the console, enter
+Open this lesson's `index.html` file in your browser (http://learn-co-curriculum.github.io/creating-and-inserting-dom-nodes/) and open up the browser's console. In the console, enter
 
 ``` javascript
 var element = document.createElement('div')


### PR DESCRIPTION
@curiositypaths 
Just had a question from a student in bootcamp prep (they don't have the IDE sandbox feature yet). For students using the IDE in browser, they won't have access to an editor here, so it's awkward to get access to the file and open it in the browser, so I added a GitHub pages link to the readme.